### PR TITLE
Adds DOD as a scope to fromNetwork lambda 

### DIFF
--- a/dod/build.gradle.kts
+++ b/dod/build.gradle.kts
@@ -28,7 +28,7 @@ publishKotlinFix()
 configure<PublishExtension> {
     val groupProjectID = "com.revolut.rxdata"
     val artifactProjectID = "dod"
-    val publishVersionID = "1.2.1"
+    val publishVersionID = "1.2.2"
 
     bintrayUser = BINTRAY_USER
     bintrayKey = BINTRAY_KEY

--- a/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
@@ -41,6 +41,9 @@ class DataObservableDelegateTest {
 
     private lateinit var fromNetwork: (Params) -> Single<Domain>
 
+    private val fromNetworkScoped: DataObservableDelegate<Params, Domain>.(Params) -> Single<Domain> =
+        { fromNetwork(it) }
+
     private lateinit var toMemory: (Params, Domain) -> Unit
 
     private lateinit var fromMemory: (Params) -> Domain
@@ -63,7 +66,7 @@ class DataObservableDelegateTest {
         fromStorage = mock()
 
         dataObservableDelegate = DataObservableDelegate(
-            fromNetwork = fromNetwork,
+            fromNetwork = fromNetworkScoped,
             fromMemory = fromMemory,
             toMemory = toMemory,
             fromStorage = fromStorage,


### PR DESCRIPTION
and additional params to notifyFromMemor. 

Dod is added as a scope because observableDelegate can't be referred inside fromNetwork lambda in cases like this: 

```kotlin
private val observableDelegate: DataObservableDelegate<String, InsightInfo> = DataObservableDelegate(
    fromNetwork = { params ->
        service.getSomeStuff(params).map { it.toDomain() }
            .doOnError {
                this.notifyFromMemory(error = it, loading = true) { it == params }
            }
            .retryOnConnectivityRestore(connectivityRepository)
    },
    fromMemory = { key -> memoryCache[key] },
    toMemory = { key, data -> memoryCache[key] = data }
)
```