### PR TITLE
Fix: notifyFromMemory not working 

### DIFF
--- a/dod/build.gradle.kts
+++ b/dod/build.gradle.kts
@@ -28,7 +28,7 @@ publishKotlinFix()
 configure<PublishExtension> {
     val groupProjectID = "com.revolut.rxdata"
     val artifactProjectID = "dod"
-    val publishVersionID = "1.2.2"
+    val publishVersionID = "1.2.3"
 
     bintrayUser = BINTRAY_USER
     bintrayKey = BINTRAY_KEY

--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -71,9 +71,10 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                         toMemory(params, value)
                     }
                 }
+                .toObservable()
                 .subscribeOn(Schedulers.io())
-                .takeIf { memoryIsEmpty } ?: Single.just(Data(content = memCache)))
-                .flatMapObservable { cachedValue ->
+                .takeIf { memoryIsEmpty } ?: just(Data(content = memCache)))
+                .flatMap { cachedValue ->
                     if (forceReload || memoryIsEmpty) {
                         val data = cachedValue.copy(loading = true)
                         subject.onNext(data)

--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -65,7 +65,6 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
             val memoryIsEmpty = memCache == null
             val subject = subject(params)
 
-            //Just storage or memory Single as Observable
             (fromStorageSingle(params)
                 .doOnSuccess { cachedValue ->
                     cachedValue.content?.let { value ->
@@ -74,7 +73,6 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                 }
                 .subscribeOn(Schedulers.io())
                 .takeIf { memoryIsEmpty } ?: Single.just(Data(content = memCache)))
-
                 .flatMapObservable { cachedValue ->
                     if (forceReload || memoryIsEmpty) {
                         val data = cachedValue.copy(loading = true)
@@ -91,8 +89,6 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                         )
                     }
                 }
-
-                //on storage or memory error
                 .onErrorResumeNext { _: Throwable ->
                     val data = Data(content = null, loading = true)
                     subject.onNext(data)

--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -2,6 +2,8 @@ package com.revolut.rxdata.dod
 
 import com.revolut.rxdata.core.Data
 import io.reactivex.Observable
+import io.reactivex.Observable.concat
+import io.reactivex.Observable.just
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
@@ -63,30 +65,45 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
             val memoryIsEmpty = memCache == null
             val subject = subject(params)
 
+            //Just storage or memory Single as Observable
             (fromStorageSingle(params)
                 .doOnSuccess { cachedValue ->
                     cachedValue.content?.let { value ->
                         toMemory(params, value)
                     }
                 }
-                .toObservable()
                 .subscribeOn(Schedulers.io())
-                .takeIf { memoryIsEmpty } ?: Observable.just(Data(content = memCache)))
-                .flatMap { cachedValue ->
+                .takeIf { memoryIsEmpty } ?: Single.just(Data(content = memCache)))
+
+                .flatMapObservable { cachedValue ->
                     if (forceReload || memoryIsEmpty) {
                         val data = cachedValue.copy(loading = true)
                         subject.onNext(data)
-                        fetchFromNetwork(cachedValue.content, params).startWith(data)
+
+                        concat(
+                            just(data),
+                            fetchFromNetwork(cachedValue.content, params).mergeWith(subject)
+                        )
                     } else {
-                        Observable.just(cachedValue)
+                        concat(
+                            just(cachedValue),
+                            subject
+                        )
                     }
                 }
+
+                //on storage or memory error
                 .onErrorResumeNext { _: Throwable ->
                     val data = Data(content = null, loading = true)
                     subject.onNext(data)
-                    fetchFromNetwork(null, params).startWith(data)
+
+                    concat(
+                        just(data),
+                        fetchFromNetwork(null, params).mergeWith(subject)
+                    )
                 }
-                .concatWith(subject.distinctUntilChanged())
+                .distinctUntilChanged()
+
         }
 
     /**


### PR DESCRIPTION
... until fromNetwork is terminated, due to internal .concatWith(subject) which isn't subscribed until terminal event 