### PR TITLE
Add switchMapData extension

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,7 +22,7 @@ publishKotlinFix()
 configure<PublishExtension> {
     val groupProjectID = "com.revolut.rxdata"
     val artifactProjectID = "core"
-    val publishVersionID = "1.2.6"
+    val publishVersionID = "1.2.7"
 
     bintrayUser = BINTRAY_USER
     bintrayKey = BINTRAY_KEY

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
@@ -82,7 +82,7 @@ fun <T, R> Observable<Data<T>>.switchMapDataContentSingle(block: (T) -> Single<R
         }
     }
 
-fun <T, R> Observable<Data<T>>.switchMapDataContentToData(block: (T) -> Observable<Data<R>>): Observable<Data<R>> =
+fun <T, R> Observable<Data<T>>.switchMapData(block: (T) -> Observable<Data<R>>): Observable<Data<R>> =
     switchMap { original ->
         if (original.content != null) {
             try {

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
@@ -82,6 +82,28 @@ fun <T, R> Observable<Data<T>>.switchMapDataContentSingle(block: (T) -> Single<R
         }
     }
 
+fun <T, R> Observable<Data<T>>.switchMapDataContentToData(block: (T) -> Observable<Data<R>>): Observable<Data<R>> =
+    switchMap { original ->
+        if (original.content != null) {
+            try {
+                block(original.content)
+            } catch (t: Throwable) {
+                Observable.just(
+                    Data<R>(
+                        error = combineErrors(original.error, t),
+                        loading = original.loading
+                    )
+                )
+            }
+        } else {
+            Observable.just(
+                Data(
+                    error = original.error,
+                    loading = original.loading
+                )
+            )
+        }
+    }
 
 private fun combineErrors(
     firstError: Throwable?,


### PR DESCRIPTION
## Add switchMapDataContentToData extension

In such situations:

```kotlin
fun observeFoo(): Observable<Data<Foo>> { /* ... */ }
fun observeBar(foo: Foo): Observable<Data<Bar>> { /* ... */ }

fun observeResult(): Observable<Data<Data<Bar>>> = 
    observeFoo()
        .switchMapDataContent { foo -> observeBar(foo) }
```

`Data<Data<Bar>>` is not that expected.

I see a lot of solutions like this:

```kotlin
fun observeResult(): Observable<Data<Data<Bar>>> = 
    observeFoo()
        .switchMapDataContent { foo -> 
            observeBar(foo).extractDataOrError() 
        }
```

Or even this:

```kotlin
fun observeResult(): Observable<Data<Data<Bar>>> = 
    observeFoo()
        .switchMapDataContent { foo -> observeBar(foo) }
        .extractDataOrError() 
        .extractDataOrError() 
```

This new extension allows to simplify this:

```kotlin
fun observeResult(): Observable<Data<Bar>>> = 
    observeFoo()
        .switchMapData { foo -> observeBar(foo) }
```

The behavior will be the same: the old `switchMapDataContent` provides `content` from the transformed stream with the `loading` and `error` from the original stream, because it was supposed that the transformed stream does not emit `Data`.

This new extension method avoids wrapping of `Data` into `Data` so then extracting, etc. is not necessary,
and no `loading`s, `error`s, or `content`s are lost.

Similar to (old & deprecated and based in core module)`switchMapData` extension, but has better implementation.