### PR TITLE
Deprecate extractData, introduce extractContent

### DIFF
--- a/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
@@ -6,11 +6,6 @@ import io.reactivex.Observable
 
 fun <T> Observable<Data<T>>.extractContent(
     /**
-     * If false, error will terminate the stream only if content isn't present,
-     * if true error will terminate the stream regardless of the content
-     */
-    strictErrors: Boolean = true,
-    /**
      * Allows to substitute null content with some object by provided loading and error.
      */
     nullContentHandler: (loading: Boolean, error: Throwable?) -> T? = { _, _ -> null },
@@ -24,7 +19,7 @@ fun <T> Observable<Data<T>>.extractContent(
         consumeErrors(error, it.content)
     }
 
-    if (error != null && (strictErrors || it.content == null)) {
+    if (error != null) {
         throw error
     }
 

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
@@ -6,10 +6,6 @@ import io.reactivex.Observable
 
 fun <T> Observable<Data<T>>.extractContent(
     /**
-     * If true - then emits where loading == true will be filtered out (including errors emits).
-     */
-    filterLoading: Boolean = false,
-    /**
      * If false, error will terminate the stream only if content isn't present,
      * if true error will terminate the stream regardless of the content
      */
@@ -19,17 +15,14 @@ fun <T> Observable<Data<T>>.extractContent(
      * Normal usage is to return null for all known errors so that they don't terminate the stream.
      */
     consumeErrors: (Throwable, T?) -> Throwable? = { e, _ -> e }
-): Observable<T> =
-    filter {
-        !(filterLoading && it.loading)
-    }.map {
-        val error = it.error?.let { error ->
-            consumeErrors(error, it.content)
-        }
+): Observable<T> = map {
+    val error = it.error?.let { error ->
+        consumeErrors(error, it.content)
+    }
 
-        if (error != null && (strictErrors || it.content == null)) {
-            throw error
-        }
-        it
-    }.filter { it.content != null }.map { it.content }
+    if (error != null && (strictErrors || it.content == null)) {
+        throw error
+    }
+    it
+}.filter { it.content != null }.map { it.content }
 

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractContent.kt
@@ -1,0 +1,35 @@
+package com.revolut.rxdata.core.extensions
+
+import com.revolut.rxdata.core.Data
+import io.reactivex.Observable
+
+
+fun <T> Observable<Data<T>>.extractContent(
+    /**
+     * If true - then emits where loading == true will be filtered out (including errors emits).
+     */
+    filterLoading: Boolean = false,
+    /**
+     * If false, error will terminate the stream only if content isn't present,
+     * if true error will terminate the stream regardless of the content
+     */
+    strictErrors: Boolean = true,
+    /**
+     * Original error will be replaced with the one returned by this lambda.
+     * Normal usage is to return null for all known errors so that they don't terminate the stream.
+     */
+    consumeErrors: (Throwable, T?) -> Throwable? = { e, _ -> e }
+): Observable<T> =
+    filter {
+        !(filterLoading && it.loading)
+    }.map {
+        val error = it.error?.let { error ->
+            consumeErrors(error, it.content)
+        }
+
+        if (error != null && (strictErrors || it.content == null)) {
+            throw error
+        }
+        it
+    }.filter { it.content != null }.map { it.content }
+

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractData.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractData.kt
@@ -20,9 +20,17 @@ import io.reactivex.Observable
  *
  */
 
+@Deprecated(
+    replaceWith = ReplaceWith("extractContent(filterLoading = false, strictErrors = false)"),
+    message = "Dangerous method, ignores errors, replace with extractContent(filterLoading = false, strictErrors = false)"
+)
 fun <T> Observable<Data<T>>.extractData(): Observable<T> =
     filter { it.content != null }.map { it.content!! }
 
+@Deprecated(
+    message = "Use newer extractContent for content extraction, " +
+            "extracting errors shouldn't be done separately"
+)
 fun <T> Observable<Data<T>>.extractError(): Observable<Data<T>> {
     return flatMap {
         if (it.error != null && it.content == null) {
@@ -33,8 +41,18 @@ fun <T> Observable<Data<T>>.extractError(): Observable<Data<T>> {
     }
 }
 
+@Deprecated(
+    replaceWith = ReplaceWith("extractContent(filterLoading = false, strictErrors = false)"),
+    message = "Use newer extractContent for content extraction, " +
+            "its non strict behaviour extracts errors when content is null"
+)
 fun <T> Observable<Data<T>>.extractDataOrError(): Observable<T> = extractError().extractData()
 
+@Deprecated(
+    replaceWith = ReplaceWith("extractContent(filterLoading = false, strictErrors = true)"),
+    message = "Use newer extractContent for content extraction, " +
+            "its strict behaviour extracts errors even when content is present"
+)
 fun <T> Observable<Data<T>>.extractErrorStrict(): Observable<Data<T>> = flatMap {
     if (it.error != null) {
         Observable.error(it.error)
@@ -43,6 +61,12 @@ fun <T> Observable<Data<T>>.extractErrorStrict(): Observable<Data<T>> = flatMap 
     }
 }
 
+@Deprecated(
+    replaceWith = ReplaceWith("extractContent(filterLoading = true)"),
+    message = "Use newer extractContent for content extraction, " +
+            "filterLoading = true will filter out emits where loading is true. " +
+            "Pay attention to error extraction policy"
+)
 fun <T> Observable<Data<T>>.extractDataIfLoaded(): Observable<T> {
     return filter { it.content != null && !it.loading }
         .map { it.content!! }

--- a/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractData.kt
+++ b/core/src/main/java/com/revolut/rxdata/core/extensions/ExtractData.kt
@@ -42,14 +42,14 @@ fun <T> Observable<Data<T>>.extractError(): Observable<Data<T>> {
 }
 
 @Deprecated(
-    replaceWith = ReplaceWith("extractContent(filterLoading = false, strictErrors = false)"),
+    replaceWith = ReplaceWith("extractContent(strictErrors = false)"),
     message = "Use newer extractContent for content extraction, " +
             "its non strict behaviour extracts errors when content is null"
 )
 fun <T> Observable<Data<T>>.extractDataOrError(): Observable<T> = extractError().extractData()
 
 @Deprecated(
-    replaceWith = ReplaceWith("extractContent(filterLoading = false, strictErrors = true)"),
+    replaceWith = ReplaceWith("extractContent(strictErrors = true)"),
     message = "Use newer extractContent for content extraction, " +
             "its strict behaviour extracts errors even when content is present"
 )
@@ -62,10 +62,10 @@ fun <T> Observable<Data<T>>.extractErrorStrict(): Observable<Data<T>> = flatMap 
 }
 
 @Deprecated(
-    replaceWith = ReplaceWith("extractContent(filterLoading = true)"),
+    replaceWith = ReplaceWith("filterWhileLoading().extractContent()"),
     message = "Use newer extractContent for content extraction, " +
-            "filterLoading = true will filter out emits where loading is true. " +
-            "Pay attention to error extraction policy"
+            "filterWhileLoading will filter out emits where loading is true. " +
+            "Pay attention to error extraction behaviour changes in ExtractDataKtTest"
 )
 fun <T> Observable<Data<T>>.extractDataIfLoaded(): Observable<T> {
     return filter { it.content != null && !it.loading }

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
@@ -20,7 +20,7 @@ class CombineDataKtPairTest {
 
         testCombinedAB = combineLatestData(aSubject, bSubject)
             .mapData { (a, b) -> a + b }
-            .extractContent(strictErrors = false)
+            .extractContent()
             .test()
     }
 

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
@@ -20,7 +20,7 @@ class CombineDataKtPairTest {
 
         testCombinedAB = combineLatestData(aSubject, bSubject)
             .mapData { (a, b) -> a + b }
-            .extractContent(filterLoading = false, strictErrors = false)
+            .extractContent(strictErrors = false)
             .test()
     }
 

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
@@ -19,7 +19,9 @@ class CombineDataKtPairTest {
         bSubject = PublishSubject.create()
 
         testCombinedAB = combineLatestData(aSubject, bSubject)
-            .mapData { (a, b) -> a + b }.extractData().test()
+            .mapData { (a, b) -> a + b }
+            .extractContent(filterLoading = false, strictErrors = false)
+            .test()
     }
 
     @Test

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
@@ -22,7 +22,7 @@ class CombineDataKtTripleTest {
 
         testCombinedABC = combineLatestData(aSubject, bSubject, cSubject)
             .mapData { (a, b, c) -> a + b + c }
-            .extractContent(strictErrors = false)
+            .extractContent()
             .test()
     }
 

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
@@ -21,7 +21,9 @@ class CombineDataKtTripleTest {
         cSubject = PublishSubject.create()
 
         testCombinedABC = combineLatestData(aSubject, bSubject, cSubject)
-            .mapData { (a, b, c) -> a + b + c }.extractData().test()
+            .mapData { (a, b, c) -> a + b + c }
+            .extractContent(filterLoading = false, strictErrors = false)
+            .test()
     }
 
     @Test

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
@@ -22,7 +22,7 @@ class CombineDataKtTripleTest {
 
         testCombinedABC = combineLatestData(aSubject, bSubject, cSubject)
             .mapData { (a, b, c) -> a + b + c }
-            .extractContent(filterLoading = false, strictErrors = false)
+            .extractContent(strictErrors = false)
             .test()
     }
 

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
@@ -1,0 +1,160 @@
+package com.revolut.rxdata.core.extensions
+
+import com.revolut.rxdata.core.Data
+import io.reactivex.Observable
+import org.junit.Test
+
+class ExtractContentKtTest {
+
+    //region default params: filterLoading = false | strictErrors = true
+
+    @Test
+    fun `Null content emits are skipped`() {
+        Observable.just(
+            Data(null, null, loading = true),
+            Data("A", null, loading = false)
+        ).extractContent().test().assertValues("A")
+    }
+
+    @Test
+    fun `Loading items are not skipped`() {
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false)
+        ).extractContent(filterLoading = false).test().assertValues("A", "B")
+    }
+
+    @Test
+    fun `Errors with content terminate the stream`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", error, loading = true)
+        ).extractContent().test().assertError(error)
+    }
+
+    @Test
+    fun `Errors without content terminate the stream`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data(null, error, loading = true)
+        ).extractContent().test().assertError(error)
+    }
+
+    //endregion
+
+    //region filterLoading = true | strictErrors = true
+
+    @Test
+    fun `Loading items are skipped`() {
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false)
+        ).extractContent(filterLoading = true).test().assertValues("B")
+    }
+
+    @Test
+    fun `Loading items with errors are skipped`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", error, loading = true),
+            Data("B", null, loading = false)
+        ).extractContent(filterLoading = true).test().assertValues("B")
+    }
+
+    @Test
+    fun `Error after loading`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("A", error, loading = false)
+        ).extractContent(filterLoading = true).test().assertNoValues().assertError(error)
+    }
+
+    //endregion
+
+    //region filterLoading = false | strictErrors = false
+
+    @Test
+    fun `Errors with content do not terminate the stream`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", error, loading = true)
+        ).extractContent(strictErrors = false).test().assertValues("A")
+    }
+
+    @Test
+    fun `Errors without content still terminate the stream`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data(null, error, loading = true)
+        ).extractContent(strictErrors = false).test().assertError(error)
+    }
+
+    //endregion
+
+    //region filterLoading = true | strictErrors = false
+
+    @Test
+    fun `Error with content is not extracted`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", error, loading = false)
+        ).extractContent(filterLoading = true, strictErrors = false).test().assertValues("B")
+    }
+
+    @Test
+    fun `Error without content is extracted and terminates the stream`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data(null, error, loading = false)
+        ).extractContent(filterLoading = true, strictErrors = false).test()
+            .assertNoValues().assertError(error)
+    }
+
+    //endregion
+
+    //region errors consumer
+
+    @Test
+    fun `When error is consumed then downstream receives a value`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", error, loading = true)
+        ).extractContent(consumeErrors = { e, _ ->
+            when (e) {
+                is IllegalStateException -> null
+                else -> e
+            }
+        }).test().assertValues("A").assertNoErrors()
+    }
+
+    @Test
+    fun `Conditional error consuming`() {
+        val error = IllegalStateException()
+
+        Observable.just(
+            Data("A", error, loading = true), //error consumed, value emitted downstream
+            Data("B", error, loading = true) // error not consumed, error is extracted
+        ).extractContent(consumeErrors = { e, content ->
+            if (e is IllegalStateException && content == "A") {
+                null
+            } else {
+                e
+            }
+        }).test().assertValues("A").assertError(error)
+    }
+
+    //endregion
+
+}

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class ExtractContentKtTest {
 
-    //region default params: filterLoading = false | strictErrors = true
+    //region default params strictErrors = true
 
     @Test
     fun `Null content emits are skipped`() {
@@ -21,7 +21,7 @@ class ExtractContentKtTest {
         Observable.just(
             Data("A", null, loading = true),
             Data("B", null, loading = false)
-        ).extractContent(filterLoading = false).test().assertValues("A", "B")
+        ).extractContent().test().assertValues("A", "B")
     }
 
     @Test
@@ -44,14 +44,14 @@ class ExtractContentKtTest {
 
     //endregion
 
-    //region filterLoading = true | strictErrors = true
+    //region filterWhileLoading | strictErrors = true
 
     @Test
     fun `Loading items are skipped`() {
         Observable.just(
             Data("A", null, loading = true),
             Data("B", null, loading = false)
-        ).extractContent(filterLoading = true).test().assertValues("B")
+        ).filterWhileLoading().extractContent().test().assertValues("B")
     }
 
     @Test
@@ -61,7 +61,7 @@ class ExtractContentKtTest {
         Observable.just(
             Data("A", error, loading = true),
             Data("B", null, loading = false)
-        ).extractContent(filterLoading = true).test().assertValues("B")
+        ).filterWhileLoading().extractContent().test().assertValues("B")
     }
 
     @Test
@@ -71,12 +71,12 @@ class ExtractContentKtTest {
         Observable.just(
             Data("A", null, loading = true),
             Data("A", error, loading = false)
-        ).extractContent(filterLoading = true).test().assertNoValues().assertError(error)
+        ).filterWhileLoading().extractContent().test().assertNoValues().assertError(error)
     }
 
     //endregion
 
-    //region filterLoading = false | strictErrors = false
+    //region strictErrors = false
 
     @Test
     fun `Errors with content do not terminate the stream`() {
@@ -98,7 +98,7 @@ class ExtractContentKtTest {
 
     //endregion
 
-    //region filterLoading = true | strictErrors = false
+    //region filterWhileLoading | strictErrors = false
 
     @Test
     fun `Error with content is not extracted`() {
@@ -107,7 +107,7 @@ class ExtractContentKtTest {
         Observable.just(
             Data("A", null, loading = true),
             Data("B", error, loading = false)
-        ).extractContent(filterLoading = true, strictErrors = false).test().assertValues("B")
+        ).filterWhileLoading().extractContent(strictErrors = false).test().assertValues("B")
     }
 
     @Test
@@ -117,7 +117,7 @@ class ExtractContentKtTest {
         Observable.just(
             Data("A", null, loading = true),
             Data(null, error, loading = false)
-        ).extractContent(filterLoading = true, strictErrors = false).test()
+        ).filterWhileLoading().extractContent(strictErrors = false).test()
             .assertNoValues().assertError(error)
     }
 

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
@@ -138,7 +138,7 @@ class ExtractContentKtTest {
 
     //endregion
 
-    //region nullContentHandler with consumeErrors
+    //region nullContentHandler
 
     @Test
     fun `Replace null content when error happened and consume that error`() {
@@ -162,6 +162,21 @@ class ExtractContentKtTest {
                     e
                 }
             }).test().assertValues("A").assertNoErrors()
+    }
+
+    @Test
+    fun `Replace null with default content when loading`() {
+        Observable.just(
+            Data(null, null, loading = true),
+            Data("B", null, loading = false)
+        ).extractContent(
+            nullContentHandler = { loading, _ ->
+                if (loading) {
+                    "A"
+                } else {
+                    null
+                }
+            }).test().assertValues("A", "B").assertNoErrors()
     }
 
     //endregion

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
@@ -157,4 +157,32 @@ class ExtractContentKtTest {
 
     //endregion
 
+    //region nullContentHandler
+
+    @Test
+    fun `Replace null content when error happened and consume that error`() {
+        val error = IllegalStateException()
+
+        Observable.just<Data<String>>(
+            Data(null, null, loading = true), //error consumed, value emitted downstream
+            Data(null, error, loading = false) // error not consumed, error is extracted
+        ).extractContent(
+            nullContentHandler = { loading, e ->
+                if (e is IllegalStateException && !loading) {
+                    "A"
+                } else {
+                    null
+                }
+            },
+            consumeErrors = { e, content ->
+                if (e is IllegalStateException && content == null) {
+                    null
+                } else {
+                    e
+                }
+            }).test().assertValues("A").assertNoErrors()
+    }
+
+    //endregion
+
 }

--- a/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractDataKtTest.kt
+++ b/core/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractDataKtTest.kt
@@ -1,0 +1,102 @@
+package com.revolut.rxdata.core.extensions
+
+import com.revolut.rxdata.core.Data
+import io.reactivex.Observable
+import org.junit.Test
+
+class ExtractDataKtTest {
+
+
+    @Test
+    fun `Loading items are skipped`() {
+        //Deprecated behaviour:
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false)
+        ).extractDataIfLoaded().test().assertValues("B")
+
+        //New behaviour is the same in this case:
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false)
+        ).filterWhileLoading().extractContent().test().assertValues("B")
+    }
+
+    @Test
+    fun `Loading items with errors are skipped`() {
+        val error = IllegalStateException()
+
+        //Deprecated behaviour:
+
+        Observable.just(
+            Data("A", error, loading = true),
+            Data("B", null, loading = false)
+        ).extractDataIfLoaded().test().assertValues("B")
+
+        //New behaviour is the same in this case:
+
+        Observable.just(
+            Data("A", error, loading = true),
+            Data("B", null, loading = false)
+        ).filterWhileLoading().extractContent().test().assertValues("B")
+    }
+
+    @Test
+    fun `Error after loading`() {
+        val error = IllegalStateException()
+
+        //Deprecated behaviour:
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("A", error, loading = false)
+        ).extractDataIfLoaded().test().assertValues("A")
+
+        //New behaviour:
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("A", error, loading = false)
+        ).filterWhileLoading().extractContent().test().assertNoValues().assertError(error)
+    }
+
+    @Test
+    fun `Error with content is not extracted`() {
+        val error = IllegalStateException()
+
+        //Deprecated behaviour:
+
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", error, loading = false)
+        ).extractDataIfLoaded().test().assertValues("B")
+
+        //New behaviour:
+        Observable.just(
+            Data("A", null, loading = true),
+            Data("B", error, loading = false)
+        ).filterWhileLoading().extractContent().test().assertError(error)
+    }
+
+    @Test
+    fun `Error without content is extracted and terminates the stream`() {
+        val error = IllegalStateException()
+
+        //Deprecated behaviour:
+        Observable.just(
+            Data("A", null, loading = true),
+            Data(null, error, loading = false)
+        ).extractDataIfLoaded().test()
+            .assertNoValues().assertNoErrors()
+
+        //New behaviour:
+        Observable.just(
+            Data("A", null, loading = true),
+            Data(null, error, loading = false)
+        ).filterWhileLoading().extractContent().test()
+            .assertNoValues().assertError(error)
+    }
+}
+
+


### PR DESCRIPTION
Old **extractData()** extension caused errors to be completely ignored. That's a very bad code practice and error handling wasn't enforced by the library. From now on this extension is deprecated.  And new **extractContent** is introduced.

### extractContent()

This new extension always brings errors to the downstream by default, which will cause them to terminate in such case. 
There're one explicit option for handling errors: 


### consumeErrors: (error: Throwable, content: T?) -> Throwable? = { error, content -> error }

Allows to _consume_ a known error, i.e. replace it with a null before extraction. This action is explicit and will be visible during the code review. 

Consuming specific errors: 
```
Observable.just(
            Data("A", error, loading = true), //error consumed, value emitted downstream
            Data("B", error, loading = true) // error not consumed, error is extracted
        ).extractContent(consumeErrors = { e, content ->
            if (e is IllegalStateException && content == "A") {
                null
            } else {
                e
            }
        }).test().assertValues("A").assertError(error)
```

Consume errors while loading: 

```
        Observable.just(
            Data("A", error, loading = true)
        ).extractContent(consumeErrors = { e, content ->
            if (content != null) {
                null
            } else {
                e
            }
        }).test().assertValues("A")
```


### nullContentHandler: (loading: Boolean, error: Throwable?) -> T? = { loading, error -> null }

Another parameter is nullContentHandler, it allows to replace content when it is null, and depending on loading|error. Can be used in pair with consumeErrors.

Simply replacing null content when loading with some value: 

```
        Observable.just(
            Data(null, null, loading = true),
            Data("B", null, loading = false)
        ).extractContent(
            nullContentHandler = { loading, _ ->
                if (loading) {
                    "A"
                } else {
                    null
                }
            }).test().assertValues("A", "B").assertNoErrors()
```


Consuming IllegalStateException, and replacing null content with default value when such error happen:  

```
Observable.just<Data<String>>(
            Data(null, null, loading = true), //error consumed, value emitted downstream
            Data(null, error, loading = false) // error not consumed, error is extracted
        ).extractContent(
            nullContentHandler = { loading, e ->
                if (e is IllegalStateException && !loading) {
                    "A"
                } else {
                    null
                }
            },
            consumeErrors = { e, content ->
                if (e is IllegalStateException && content == null) {
                    null
                } else {
                    e
                }
            }).test().assertValues("A").assertNoErrors()
```
