### PR TITLE
Exclude NoSuchElementException from automatic retries

### DIFF
--- a/dod/gradle.properties
+++ b/dod/gradle.properties
@@ -1,4 +1,4 @@
-publishProjectVersion=1.3.1
+publishProjectVersion=1.3.2
 
 publishArtifactProjectId=dod
 publishDescription=RxData DataObservableDelegate


### PR DESCRIPTION
... to allow external error flow control.
 
One example:
One strategy for dealing with 304s is to return a custom error in fromNetwork lambda, to be later filtered out in observe() stream. Such error would force DOD to auto retry all subsequent observe calls even with forceReload=false. 

This modification allow to return any custom subclass of NoSuchElementException to avoid auto retries. 