### PR TITLE
switchMapData ext fix, combine loading and errors

### DIFF
--- a/rx-core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
+++ b/rx-core/src/main/java/com/revolut/rxdata/core/extensions/SwitchMapData.kt
@@ -82,17 +82,24 @@ fun <T, R> Observable<Data<T>>.switchMapDataContentSingle(block: (T) -> Single<R
         }
     }
 
-fun <T, R> Observable<Data<T>>.switchMapData(block: (T) -> Observable<Data<R>>): Observable<Data<R>> =
+fun <T, R> Observable<Data<T>>.switchMapData(
+    block: (T) -> Observable<Data<R>>
+): Observable<Data<R>> =
     switchMap { original ->
         if (original.content != null) {
             try {
                 block(original.content)
-            } catch (t: Throwable) {
+            } catch (error: Throwable) {
                 Observable.just(
-                    Data<R>(
-                        error = combineErrors(original.error, t),
-                        loading = original.loading
+                    Data(
+                        error = error,
+                        loading = false
                     )
+                )
+            }.map { transformed ->
+                transformed.copy(
+                    loading = combineLoading(original.loading, transformed.loading),
+                    error = combineErrors(original.error, transformed.error)
                 )
             }
         } else {
@@ -103,7 +110,12 @@ fun <T, R> Observable<Data<T>>.switchMapData(block: (T) -> Observable<Data<R>>):
                 )
             )
         }
-    }
+    }.distinctUntilChanged()
+
+private fun combineLoading(
+    firstLoading: Boolean,
+    secondLoading: Boolean,
+): Boolean = firstLoading || secondLoading
 
 private fun combineErrors(
     firstError: Throwable?,


### PR DESCRIPTION
Current implementation of extension loses original chain loading and error states

(ObservableA(A, null, true) switchMapData -> ObservableB(B, null, false)) -> ObservableC(AB, null, false but should true)