### PR TITLE
Race condition issue

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="11">
+      <module name="RxData.dfd.main" target="1.8" />
+      <module name="RxData.dfd.test" target="1.8" />
+      <module name="RxData.dod.main" target="1.8" />
+      <module name="RxData.dod.test" target="1.8" />
+      <module name="RxData.flow-extensions.main" target="1.8" />
+      <module name="RxData.flow-extensions.test" target="1.8" />
+      <module name="RxData.model.main" target="1.8" />
+      <module name="RxData.model.test" target="1.8" />
+      <module name="RxData.rx-extensions.main" target="1.8" />
+      <module name="RxData.rx-extensions.test" target="1.8" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -8,6 +8,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -21,7 +22,6 @@
             <option value="$PROJECT_DIR$/scheduler" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.impldep.org.fusesource.jansi.AnsiRenderer.test
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -38,4 +39,9 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_1_8.toString()
         sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,7 @@ object Dependencies {
 
     const val jUnit = "junit:junit:4.13"
 
-    const val assertJCore = "org.assertj:assertj-core:$assertjVersion"
+    const val strikt = "io.strikt:strikt-core:0.34.0"
     const val jupiterApi = "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     const val jupiterParams = "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     const val jupiterEngine = "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,4 +1,3 @@
-import Versions.assertjVersion
 import Versions.coroutinesCoreVersion
 import Versions.junitVersion
 import Versions.kotlinVersion
@@ -10,7 +9,6 @@ object Versions {
     const val rxJavaVersion = "2.2.18"
     const val coroutinesCoreVersion = "1.6.0"
     const val junitVersion = "5.7.2"
-    const val assertjVersion = "3.19.0"
 }
 
 object BuildScriptDependencies {
@@ -26,8 +24,6 @@ object Dependencies {
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesCoreVersion"
     const val coroutinesCoreTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesCoreVersion"
     const val turbineCoroutinesTest = "app.cash.turbine:turbine:0.7.0"
-
-    const val jUnit = "junit:junit:4.13"
 
     const val jupiterApi = "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     const val jupiterParams = "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,4 +1,6 @@
+import Versions.assertjVersion
 import Versions.coroutinesCoreVersion
+import Versions.junitVersion
 import Versions.kotlinVersion
 import Versions.rxJavaVersion
 
@@ -7,6 +9,8 @@ object Versions {
     const val kotlinVersion = "1.6.10"
     const val rxJavaVersion = "2.2.18"
     const val coroutinesCoreVersion = "1.6.0"
+    const val junitVersion = "5.7.2"
+    const val assertjVersion = "3.19.0"
 }
 
 object BuildScriptDependencies {
@@ -24,6 +28,11 @@ object Dependencies {
     const val turbineCoroutinesTest = "app.cash.turbine:turbine:0.7.0"
 
     const val jUnit = "junit:junit:4.13"
+
+    const val assertJCore = "org.assertj:assertj-core:$assertjVersion"
+    const val jupiterApi = "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+    const val jupiterParams = "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    const val jupiterEngine = "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     const val mockitoKotlin = "com.nhaarman:mockito-kotlin:1.5.0"
     const val mockitoInline = "org.mockito:mockito-inline:3.8.0"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,6 @@ object Dependencies {
 
     const val jUnit = "junit:junit:4.13"
 
-    const val strikt = "io.strikt:strikt-core:0.34.0"
     const val jupiterApi = "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     const val jupiterParams = "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     const val jupiterEngine = "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/dfd/build.gradle.kts
+++ b/dfd/build.gradle.kts
@@ -12,7 +12,9 @@ dependencies {
     testImplementation(project(":flow-extensions"))
     testImplementation(Dependencies.coroutinesCoreTest)
     testImplementation(Dependencies.turbineCoroutinesTest)
-    testImplementation(Dependencies.jUnit)
+    testImplementation(Dependencies.jupiterApi)
+    testImplementation(Dependencies.jupiterParams)
+    testImplementation(Dependencies.jupiterEngine)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/dfd/src/main/java/com/revolut/flowdata/Extensions.kt
+++ b/dfd/src/main/java/com/revolut/flowdata/Extensions.kt
@@ -11,6 +11,6 @@ internal fun <T> Flow<T>.concatWith(nextFlow: Flow<T>) = onCompletion {
 
 internal inline fun <K, V> ConcurrentHashMap<K, V>.getOrCreate(key: K, creator: () -> V): V =
     get(key) ?: creator().let { default ->
-        putIfAbsent(key, default)
-        default
+        val previous = putIfAbsent(key, default)
+        previous ?: default
     }

--- a/dfd/src/test/java/com/revolut/flowdata/DataFlowDelegateTest.kt
+++ b/dfd/src/test/java/com/revolut/flowdata/DataFlowDelegateTest.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -18,7 +18,7 @@ class DataFlowDelegateTest {
 
     private val testDispatcher = TestCoroutineDispatcher()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         DataFlowDelegateDispatchers.setIoDispatcher(testDispatcher)
     }

--- a/dod/build.gradle.kts
+++ b/dod/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     testImplementation(Dependencies.jupiterApi)
     testImplementation(Dependencies.jupiterEngine)
     testImplementation(Dependencies.jupiterParams)
-    testImplementation(Dependencies.strikt)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/dod/build.gradle.kts
+++ b/dod/build.gradle.kts
@@ -12,7 +12,10 @@ dependencies {
     implementation(project(":model"))
 
     testImplementation(project(":rx-extensions"))
-    testImplementation(Dependencies.jUnit)
+    testImplementation(Dependencies.jupiterApi)
+    testImplementation(Dependencies.jupiterEngine)
+    testImplementation(Dependencies.jupiterParams)
+    testImplementation(Dependencies.assertJCore)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/dod/build.gradle.kts
+++ b/dod/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     testImplementation(Dependencies.jupiterApi)
     testImplementation(Dependencies.jupiterEngine)
     testImplementation(Dependencies.jupiterParams)
-    testImplementation(Dependencies.assertJCore)
+    testImplementation(Dependencies.strikt)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -12,8 +12,6 @@ import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.write
 
 /*
  * Copyright (C) 2019 Revolut
@@ -50,14 +48,11 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
     private val networkSubscriptionsContainer: DisposableContainer = DodGlobal.disposableContainer
 ) {
 
-    private val networkLock = ReentrantReadWriteLock()
-
     private val subjectsMap = ConcurrentHashMap<Params, Subject<Data<Domain>>>()
     private val sharedNetworkRequest: SharedSingleRequest<Params, Domain> =
         SharedSingleRequest { params ->
             this.fromNetwork(params)
                 .doOnSuccess { domain ->
-                    //networkLock.write {
                     failedNetworkRequests.remove(params)
 
                     toMemory(params, domain)
@@ -65,7 +60,6 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
 
                     val data = Data(content = domain)
                     subject(params).onNext(data)
-                    //}
                 }
 
         }

--- a/dod/src/main/java/com/revolut/rxdata/dod/HashMapExt.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/HashMapExt.kt
@@ -21,6 +21,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 internal inline fun <K, V> ConcurrentHashMap<K, V>.getOrCreate(key: K, creator: () -> V): V =
     get(key) ?: creator().let { default ->
-        putIfAbsent(key, default)
-        default
+        val previous = putIfAbsent(key, default)
+        previous ?: default
     }

--- a/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
@@ -8,6 +8,7 @@ import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -65,7 +66,7 @@ class DataObservableDelegateTest {
     private val memCache = hashMapOf<Params, Domain>()
     private val storage = hashMapOf<Params, Domain>()
 
-    @BeforeAll
+    @BeforeEach
     fun setUp() {
         fromNetwork = mock()
         toMemory = mock()

--- a/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
@@ -6,9 +6,9 @@ import com.revolut.rxdata.core.extensions.extractContent
 import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -65,7 +65,7 @@ class DataObservableDelegateTest {
     private val memCache = hashMapOf<Params, Domain>()
     private val storage = hashMapOf<Params, Domain>()
 
-    @Before
+    @BeforeAll
     fun setUp() {
         fromNetwork = mock()
         toMemory = mock()

--- a/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DataObservableDelegateTest.kt
@@ -6,6 +6,7 @@ import com.revolut.rxdata.core.extensions.extractContent
 import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -99,6 +100,10 @@ class DataObservableDelegateTest {
 
         RxJavaPlugins.setIoSchedulerHandler { ioScheduler }
         RxJavaPlugins.setComputationSchedulerHandler { computationScheduler }
+    }
+
+    @AfterEach fun afterEach() {
+        RxJavaPlugins.reset()
     }
 
     @Test

--- a/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
@@ -73,7 +73,7 @@ class DodFunctionalTest {
         testSubscription.awaitTerminalEvent(maxNetworkEventAwaitMillis, MILLISECONDS)
 
         // then
-        expectThat(testSubscription.isTerminated).isTrue()
+        testSubscription.assertTerminated()
     }
 
     @RepeatedTest(5)
@@ -96,7 +96,7 @@ class DodFunctionalTest {
             it.join(maxNetworkEventAwaitMillis)
         }
 
-        expectThat(completedCounter.get()).isEqualTo(count)
+        assert(completedCounter.get() == count) { "Only ${completedCounter.get()} streams terminated"}
     }
 
 }

--- a/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
@@ -10,9 +10,6 @@ import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import strikt.api.expectThat
-import strikt.assertions.isEqualTo
-import strikt.assertions.isTrue
 import java.lang.Thread.sleep
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS

--- a/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
@@ -6,6 +6,7 @@ import com.revolut.rxdata.core.extensions.takeUntilLoaded
 import io.reactivex.Single
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import org.junit.jupiter.params.ParameterizedTest
@@ -15,7 +16,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.AtomicInteger
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(PER_CLASS)
 class DodFunctionalTest {
 
     private val networkCallDurationMillis = 300L

--- a/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
@@ -1,0 +1,81 @@
+package com.revolut.rxdata.dod
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import com.revolut.rxdata.core.extensions.takeUntilLoaded
+import io.reactivex.Single
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import java.lang.Thread.sleep
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+
+class DodFunctionalTest {
+
+    private val domain: String = "domain_model"
+
+    private lateinit var fromNetwork: (Unit) -> Single<String>
+
+    private val fromNetworkScoped: DataObservableDelegate<Unit, String>.(Unit) -> Single<String> =
+        { fromNetwork(it) }
+
+    private val toMemory: (Unit, String) -> Unit = { _, _ -> }
+    private val fromMemory: (Unit) -> String = { "domain_$it" }
+    private val toStorage: (Unit, String) -> Unit = { _, _ -> }
+    private val fromStorage: (Unit) -> String = { "domain_$it" }
+
+    private lateinit var dataObservableDelegate: DataObservableDelegate<Unit, String>
+
+    private val computationScheduler = Schedulers.computation()
+    private val ioScheduler = Schedulers.io()
+
+    @BeforeEach
+    fun before() {
+        fromNetwork = mock()
+
+        dataObservableDelegate = DataObservableDelegate(
+            fromNetwork = fromNetworkScoped,
+            fromMemory = fromMemory,
+            toMemory = toMemory,
+            fromStorage = fromStorage,
+            toStorage = toStorage
+        )
+
+        RxJavaPlugins.setIoSchedulerHandler { ioScheduler }
+        RxJavaPlugins.setComputationSchedulerHandler { computationScheduler }
+
+        whenever(fromNetwork.invoke(Unit)).thenReturn(Single.fromCallable {
+            sleep(1000)
+            domain
+        })
+    }
+
+    @RepeatedTest(5)
+    fun attemptRaceCondition() {
+        // schedule 20 DODs simultaneously reloading the same network request
+        val completedCounter = AtomicInteger(0)
+        val count = 20
+
+        (1..count).map {
+            sleep(50)
+            val thread = Thread {
+                dataObservableDelegate.observe(Unit, forceReload = true)
+                    .takeUntilLoaded()
+                    .doOnComplete {
+                        completedCounter.incrementAndGet()
+                    }
+                    .test()
+                    .awaitTerminalEvent(300, SECONDS)
+            }
+            thread.start()
+            thread
+        }.forEach {
+            it.join(1000)
+        }
+
+        assert(completedCounter.get() == count) { "Only $completedCounter streams completed" }
+    }
+
+}

--- a/dod/src/test/java/com/revolut/rxdata/dod/SharedObservableRequestTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/SharedObservableRequestTest.kt
@@ -3,10 +3,10 @@ package com.revolut.rxdata.dod
 import io.reactivex.Observable
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 
 /*
  * Copyright (C) 2019 Revolut
@@ -31,7 +31,7 @@ class SharedObservableRequestTest {
 
     private val ioScheduler: TestScheduler = TestScheduler()
 
-    @Before
+    @BeforeAll
     fun setUp() {
         RxJavaPlugins.setIoSchedulerHandler { ioScheduler }
     }

--- a/dod/src/test/java/com/revolut/rxdata/dod/SharedObservableRequestTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/SharedObservableRequestTest.kt
@@ -6,6 +6,7 @@ import io.reactivex.schedulers.TestScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /*
@@ -31,7 +32,7 @@ class SharedObservableRequestTest {
 
     private val ioScheduler: TestScheduler = TestScheduler()
 
-    @BeforeAll
+    @BeforeEach
     fun setUp() {
         RxJavaPlugins.setIoSchedulerHandler { ioScheduler }
     }

--- a/dod/src/test/kotlin/com/revolut/rxdata/dod/ReloadingDataScannerTest.kt
+++ b/dod/src/test/kotlin/com/revolut/rxdata/dod/ReloadingDataScannerTest.kt
@@ -3,6 +3,7 @@ package com.revolut.rxdata.dod
 import com.revolut.data.model.Data
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.IOException
 
@@ -10,7 +11,7 @@ class ReloadingDataScannerTest {
 
     private lateinit var scanner: ReloadingDataScanner<String>
 
-    @BeforeAll
+    @BeforeEach
     fun setUp() {
         scanner = ReloadingDataScanner()
     }

--- a/dod/src/test/kotlin/com/revolut/rxdata/dod/ReloadingDataScannerTest.kt
+++ b/dod/src/test/kotlin/com/revolut/rxdata/dod/ReloadingDataScannerTest.kt
@@ -1,16 +1,16 @@
 package com.revolut.rxdata.dod
 
 import com.revolut.data.model.Data
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class ReloadingDataScannerTest {
 
     private lateinit var scanner: ReloadingDataScanner<String>
 
-    @Before
+    @BeforeAll
     fun setUp() {
         scanner = ReloadingDataScanner()
     }

--- a/dod/src/test/resources/junit-platform.properties
+++ b/dod/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.config.fixed.parallelism = 4

--- a/flow-extensions/build.gradle.kts
+++ b/flow-extensions/build.gradle.kts
@@ -10,7 +10,9 @@ dependencies {
     implementation(Dependencies.kotlinStdLib)
     implementation(project(":model"))
 
-    testImplementation(Dependencies.jUnit)
+    testImplementation(Dependencies.jupiterApi)
+    testImplementation(Dependencies.jupiterEngine)
+    testImplementation(Dependencies.jupiterParams)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
     testImplementation(Dependencies.coroutinesCoreTest)

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtPairTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtPairTest.kt
@@ -5,9 +5,9 @@ import com.revolut.flow_core.extensions.runFlowTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
 class CombineDataKtPairTest {
@@ -17,7 +17,7 @@ class CombineDataKtPairTest {
 
     private lateinit var testCombinedAB: Flow<String>
 
-    @Before
+    @BeforeEach
     fun setup() {
         aFlow = MutableSharedFlow()
         bFlow = MutableSharedFlow()

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtTripleTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtTripleTest.kt
@@ -4,9 +4,9 @@ import com.revolut.data.model.Data
 import com.revolut.flow_core.extensions.runFlowTest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CombineDataKtTripleTest {
 
@@ -16,7 +16,7 @@ class CombineDataKtTripleTest {
 
     lateinit var testCombinedABC: Flow<String>
 
-    @Before
+    @BeforeEach
     fun setup() {
         aSubject = MutableSharedFlow()
         bSubject = MutableSharedFlow()

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/ExtractContentKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/ExtractContentKtTest.kt
@@ -4,12 +4,10 @@ import app.cash.turbine.Event
 import app.cash.turbine.test
 import com.revolut.data.model.Data
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
 class ExtractContentKtTest {

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlatMapLatestContentDataKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlatMapLatestContentDataKtTest.kt
@@ -5,108 +5,90 @@ import com.revolut.data.model.Data
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 
 @ExperimentalCoroutinesApi
-@RunWith(Enclosed::class)
 class FlatMapLatestContentDataKtTest {
 
+    companion object {
+        @JvmStatic
+        fun data() = listOf(
+            arguments(true, true, true),
+            arguments(true, false, true),
+            arguments(false, true, true),
+            arguments(false, false, false),
+        )
 
-    @RunWith(Parameterized::class)
-    class LoadingTest(
-        private val loadingA: Boolean,
-        private val loadingB: Boolean,
-        private val loadingC: Boolean,
-    ) {
-
-        companion object {
-            @JvmStatic
-            @Parameters(name = "{index}: A: loading={0}, B: loading = {1}, C: loading = {2}")
-            fun data() = listOf(
-                arrayOf(true, true, true),
-                arrayOf(true, false, true),
-                arrayOf(false, true, true),
-                arrayOf(false, false, false),
-            )
-        }
-
-        @Test
-        fun `GIVEN A - loadingA, B - loadingB WHEN switching THEN C - loadingC`() = runTest {
-            val observableA = newDataObservable(loadingA)
-            val observableB = newDataObservable(loadingB)
-
-            observableA.flatMapLatestContentDataFlow { observableB }
-                .assertLoading(loadingC)
-        }
-
-        private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
-            flowOf(Data("content", error, loading))
-
-
-        private suspend fun <T> Flow<Data<T>>.assertLoading(loading: Boolean) = test {
-            assertEquals(loading, awaitItem().loading)
-            awaitComplete()
-        }
-    }
-
-    @RunWith(Parameterized::class)
-    class ErrorTest(
-        private val errorA: Throwable?,
-        private val errorB: Throwable?,
-        private val errorC: Throwable?,
-    ) {
-
-        companion object {
-            @JvmStatic
-            @Parameters(name = "{index}: A: error = {0}, B: error = {1}, C: error = {2}")
-            fun data() = listOf(
-                arrayOf<Throwable?>(null, null, null),
-                arrayOf<Throwable?>(TestThrowable("A"), null, TestThrowable("A")),
-                arrayOf<Throwable?>(null, TestThrowable("B"), TestThrowable("B")),
-                arrayOf<Throwable?>(
-                    TestThrowable("A"),
-                    TestThrowable("B"),
-                    CompositeException(
-                        listOf(
-                            TestThrowable("A"),
-                            TestThrowable("B")
-                        )
+        @JvmStatic
+        fun errors() = listOf(
+            arguments(null, null, null),
+            arguments(TestThrowable("A"), null, TestThrowable("A")),
+            arguments(null, TestThrowable("B"), TestThrowable("B")),
+            arguments(
+                TestThrowable("A"),
+                TestThrowable("B"),
+                CompositeException(
+                    listOf(
+                        TestThrowable("A"),
+                        TestThrowable("B")
                     )
-                ),
-            )
-        }
-
-        @Test
-        fun `GIVEN A - errorA, B - errorB WHEN switching THEN C - errorC`() = runTest {
-            val observableA = newDataObservable(error = errorA)
-            val observableB = newDataObservable(error = errorB)
-
-            observableA.flatMapLatestContentDataFlow { observableB }.assertError(errorC)
-        }
-
-        private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
-            flowOf(Data("content", error, loading))
-
-
-        private suspend fun <T> Flow<Data<T>>.assertError(error: Throwable?) = test {
-            val item = awaitItem()
-            assertTrue(
-                if (item.error is CompositeException) {
-                    (item.error as CompositeException).throwables == (error as CompositeException).throwables
-                } else {
-                    item.error == error
-                }
-            )
-            awaitComplete()
-        }
-
-
-        private data class TestThrowable(val name: String) : Throwable()
+                )
+            ),
+        )
     }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun `GIVEN A - loadingA, B - loadingB WHEN switching THEN C - loadingC`(
+        loadingA: Boolean,
+        loadingB: Boolean,
+        loadingC: Boolean,
+    ) = runTest {
+        val observableA = newDataObservable(loadingA)
+        val observableB = newDataObservable(loadingB)
+
+        observableA.flatMapLatestContentDataFlow { observableB }
+            .assertLoading(loadingC)
+    }
+
+    private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
+        flowOf(Data("content", error, loading))
+
+    private suspend fun <T> Flow<Data<T>>.assertLoading(loading: Boolean) = test {
+        assertEquals(loading, awaitItem().loading)
+        awaitComplete()
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("errors")
+    fun `GIVEN A - errorA, B - errorB WHEN switching THEN C - errorC`(
+        errorA: Throwable?,
+        errorB: Throwable?,
+        errorC: Throwable?,
+    ) = runTest {
+        val observableA = newDataObservable(error = errorA)
+        val observableB = newDataObservable(error = errorB)
+
+        observableA.flatMapLatestContentDataFlow { observableB }.assertError(errorC)
+    }
+
+    private suspend fun <T> Flow<Data<T>>.assertError(error: Throwable?) = test {
+        val item = awaitItem()
+        assertTrue(
+            if (item.error is CompositeException) {
+                (item.error as CompositeException).throwables == (error as CompositeException).throwables
+            } else {
+                item.error == error
+            }
+        )
+        awaitComplete()
+    }
+
+
+    private data class TestThrowable(val name: String) : Throwable()
 }

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlatMapLatestContentKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlatMapLatestContentKtTest.kt
@@ -6,49 +6,47 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 
 @ExperimentalCoroutinesApi
 class FlatMapLatestContentKtTest {
 
-    @RunWith(Parameterized::class)
-    class LoadingTest(
-        private val loadingA: Boolean,
-        private val loadingC: Boolean,
-    ) {
 
-        companion object {
-            @JvmStatic
-            @Parameters(name = "{index}: A: loading={0}, B: loading = {1}, C: loading = {2}")
-            fun data() = listOf(
-                arrayOf(true, true),
-                arrayOf(false, false),
-            )
-        }
+    companion object {
+        @JvmStatic
+        fun data(): List<Arguments> = listOf(
+            arguments(true, true),
+            arguments(false, false),
+        )
+    }
 
-        @Test
-        fun `GIVEN A - loadingA WHEN switching THEN C - loadingC`() = runTest {
-            val observableA = newDataFlow(loadingA)
-            val observableB = newFlow()
+    @ParameterizedTest
+    @MethodSource("data")
+    fun `GIVEN A - loadingA WHEN switching THEN C - loadingC`(
+        loadingA: Boolean,
+        loadingC: Boolean
+    ) = runTest {
+        val observableA = newDataFlow(loadingA)
+        val observableB = newFlow()
 
-            observableA.flatMapLatestContent{ observableB }
-                .assertLoading(loadingC)
-        }
+        observableA.flatMapLatestContent { observableB }
+            .assertLoading(loadingC)
+    }
 
-        private fun newDataFlow(loading: Boolean = false, error: Throwable? = null) =
-            flowOf(Data("content", error, loading))
+    private fun newDataFlow(loading: Boolean = false, error: Throwable? = null) =
+        flowOf(Data("content", error, loading))
 
-        private fun newFlow() =
-            flowOf(1)
+    private fun newFlow() =
+        flowOf(1)
 
-        private suspend fun <T> Flow<Data<T>>.assertLoading(loading: Boolean) = test {
-            Assert.assertEquals(loading, awaitItem().loading)
-            awaitComplete()
-        }
+    private suspend fun <T> Flow<Data<T>>.assertLoading(loading: Boolean) = test {
+        assertEquals(loading, awaitItem().loading)
+        awaitComplete()
     }
 
 }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 }
 dependencies {
 
-    testImplementation(Dependencies.jUnit)
+    testImplementation(Dependencies.jupiterEngine)
+    testImplementation(Dependencies.jupiterParams)
+    testImplementation(Dependencies.jupiterApi)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/model/src/test/kotlin/com/revolut/data/DataTest.kt
+++ b/model/src/test/kotlin/com/revolut/data/DataTest.kt
@@ -1,8 +1,8 @@
 package com.revolut.data
 
 import com.revolut.data.model.Data
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class DataTest {
 

--- a/rx-extensions/build.gradle.kts
+++ b/rx-extensions/build.gradle.kts
@@ -10,7 +10,9 @@ dependencies {
     implementation(Dependencies.kotlinStdLib)
     implementation(project(":model"))
 
-    testImplementation(Dependencies.jUnit)
+    testImplementation(Dependencies.jupiterEngine)
+    testImplementation(Dependencies.jupiterParams)
+    testImplementation(Dependencies.jupiterApi)
     testImplementation(Dependencies.mockitoKotlin)
     testImplementation(Dependencies.mockitoInline)
 }

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtPairTest.kt
@@ -3,8 +3,8 @@ package com.revolut.rxdata.core.extensions
 import com.revolut.data.model.Data
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CombineDataKtPairTest {
 
@@ -13,7 +13,7 @@ class CombineDataKtPairTest {
 
     lateinit var testCombinedAB: TestObserver<String>
 
-    @Before
+    @BeforeEach
     fun setup() {
         aSubject = PublishSubject.create()
         bSubject = PublishSubject.create()

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/CombineDataKtTripleTest.kt
@@ -3,8 +3,8 @@ package com.revolut.rxdata.core.extensions
 import com.revolut.data.model.Data
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CombineDataKtTripleTest {
 
@@ -14,7 +14,7 @@ class CombineDataKtTripleTest {
 
     lateinit var testCombinedABC: TestObserver<String>
 
-    @Before
+    @BeforeEach
     fun setup() {
         aSubject = PublishSubject.create()
         bSubject = PublishSubject.create()

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractContentKtTest.kt
@@ -2,7 +2,7 @@ package com.revolut.rxdata.core.extensions
 
 import com.revolut.data.model.Data
 import io.reactivex.Observable
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ExtractContentKtTest {
 

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractDataKtTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/ExtractDataKtTest.kt
@@ -2,7 +2,7 @@ package com.revolut.rxdata.core.extensions
 
 import com.revolut.data.model.Data
 import io.reactivex.Observable
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ExtractDataKtTest {
 

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/SwitchMapDataTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/core/extensions/SwitchMapDataTest.kt
@@ -1,99 +1,86 @@
 package com.revolut.rxdata.core.extensions
 
-import com.revolut.rxdata.core.CompositeException
 import com.revolut.data.model.Data
+import com.revolut.rxdata.core.CompositeException
 import io.reactivex.Observable
-import org.junit.Test
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 
-@RunWith(Enclosed::class)
 class SwitchMapDataTest {
 
-    @RunWith(Parameterized::class)
-    class LoadingTest(
-        private val loadingA: Boolean,
-        private val loadingB: Boolean,
-        private val loadingC: Boolean,
-    ) {
 
-        companion object {
-            @JvmStatic
-            @Parameterized.Parameters(name = "{index}: A: loading={0}, B: loading = {1}, C: loading = {2}")
-            fun data() = listOf(
-                arrayOf(true, true, true),
-                arrayOf(true, false, true),
-                arrayOf(false, true, true),
-                arrayOf(false, false, false),
-            )
-        }
-
-        @Test
-        fun `GIVEN A - loadingA, B - loadingB WHEN switching THEN C - loadingC`() {
-            val observableA = newDataObservable(loadingA)
-            val observableB = newDataObservable(loadingB)
-
-            observableA.switchMapData { observableB }.assertLoading(loadingC)
-        }
-
-        private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
-            Observable.just(Data("content", error, loading))
-
-
-        private fun <T> Observable<Data<T>>.assertLoading(loading: Boolean) =
-            test().assertValue { it.loading == loading }
-    }
-
-
-    @RunWith(Parameterized::class)
-    class ErrorTest(
-        private val errorA: Throwable?,
-        private val errorB: Throwable?,
-        private val errorC: Throwable?,
-    ) {
-
-        companion object {
-            @JvmStatic
-            @Parameterized.Parameters(name = "{index}: A: error = {0}, B: error = {1}, C: error = {2}")
-            fun data() = listOf(
-                arrayOf<Throwable?>(null, null, null),
-                arrayOf<Throwable?>(TestThrowable("A"), null, TestThrowable("A")),
-                arrayOf<Throwable?>(null, TestThrowable("B"), TestThrowable("B")),
-                arrayOf<Throwable?>(
-                    TestThrowable("A"),
-                    TestThrowable("B"),
-                    CompositeException(
-                        listOf(
-                            TestThrowable("A"),
-                            TestThrowable("B")
-                        )
-                    )
-                ),
-            )
-        }
-
-        @Test
-        fun `GIVEN A - errorA, B - errorB WHEN switching THEN C - errorC`() {
-            val observableA = newDataObservable(error = errorA)
-            val observableB = newDataObservable(error = errorB)
-
-            observableA.switchMapData { observableB }.assertError(errorC)
-        }
-
-        private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
-            Observable.just(Data("content", error, loading))
-
-
-        private fun <T> Observable<Data<T>>.assertError(error: Throwable?) =
-            test().assertValue {
-                if (it.error is CompositeException) {
-                    (it.error as CompositeException).throwables == (error as CompositeException).throwables
-                } else {
-                    it.error == error
-                }
-            }
+    companion object {
 
         private data class TestThrowable(val name: String) : Throwable()
+
+        @JvmStatic
+        fun data() = listOf(
+            arguments(true, true, true),
+            arguments(true, false, true),
+            arguments(false, true, true),
+            arguments(false, false, false),
+        )
+
+        @JvmStatic
+        fun errors() = listOf(
+            arguments(null, null, null),
+            arguments(TestThrowable("A"), null, TestThrowable("A")),
+            arguments(null, TestThrowable("B"), TestThrowable("B")),
+            arguments(
+                TestThrowable("A"),
+                TestThrowable("B"),
+                CompositeException(
+                    listOf(
+                        TestThrowable("A"),
+                        TestThrowable("B")
+                    )
+                )
+            ),
+        )
     }
+
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun `GIVEN A - loadingA, B - loadingB WHEN switching THEN C - loadingC`(
+        loadingA: Boolean,
+        loadingB: Boolean,
+        loadingC: Boolean,
+    ) {
+        val observableA = newDataObservable(loadingA)
+        val observableB = newDataObservable(loadingB)
+
+        observableA.switchMapData { observableB }.assertLoading(loadingC)
+    }
+
+    private fun <T> Observable<Data<T>>.assertLoading(loading: Boolean) =
+        test().assertValue { it.loading == loading }
+
+    @ParameterizedTest
+    @MethodSource("errors")
+    fun `GIVEN A - errorA, B - errorB WHEN switching THEN C - errorC`(
+        errorA: Throwable?,
+        errorB: Throwable?,
+        errorC: Throwable?,
+    ) {
+        val observableA = newDataObservable(error = errorA)
+        val observableB = newDataObservable(error = errorB)
+
+        observableA.switchMapData { observableB }.assertError(errorC)
+    }
+
+    private fun newDataObservable(loading: Boolean = false, error: Throwable? = null) =
+        Observable.just(Data("content", error, loading))
+
+
+    private fun <T> Observable<Data<T>>.assertError(error: Throwable?) =
+        test().assertValue {
+            if (it.error is CompositeException) {
+                (it.error as CompositeException).throwables == (error as CompositeException).throwables
+            } else {
+                it.error == error
+            }
+        }
+
 }

--- a/rx-extensions/src/test/kotlin/com/revolut/rxdata/extensions/DataExtensionsKtTest.kt
+++ b/rx-extensions/src/test/kotlin/com/revolut/rxdata/extensions/DataExtensionsKtTest.kt
@@ -6,8 +6,8 @@ import com.revolut.rxdata.core.extensions.isEmpty
 import com.revolut.rxdata.core.extensions.isNotEmpty
 import com.revolut.rxdata.core.extensions.mapData
 import com.revolut.rxdata.core.extensions.mapDataErrorToContent
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 /*
  * Copyright (C) 2020 Revolut

--- a/scheduler/build.gradle.kts
+++ b/scheduler/build.gradle.kts
@@ -47,3 +47,7 @@ plugins.withId("com.vanniktech.maven.publish") {
         sonatypeHost = SonatypeHost.S01
     }
 }
+
+tasks.withType<Test> {
+    useJUnit()
+}


### PR DESCRIPTION
Fixes race condition in improperly written `ConcurrentHashMap<K, V>.getOrCreate` extension. 

Introduces JUnit 5 which parallel execution feature helped track down this nasty error. 
