### PR TITLE
Add takeUntilLoaded function for Flow<Data<T>>

### DIFF
--- a/flow-extensions/src/main/java/com/revolut/flowdata/extensions/LoadingExtensions.kt
+++ b/flow-extensions/src/main/java/com/revolut/flowdata/extensions/LoadingExtensions.kt
@@ -3,6 +3,7 @@ package com.revolut.flowdata.extensions
 import com.revolut.data.model.Data
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.transformWhile
 
 /*
  * Copyright (C) 2022 Revolut
@@ -23,3 +24,9 @@ import kotlinx.coroutines.flow.filter
 
 fun <T> Flow<Data<T>>.filterWhileLoading(): Flow<Data<T>> =
     filter { data -> !data.loading }
+
+fun <T> Flow<Data<T>>.takeUntilLoaded(): Flow<Data<T>> =
+    transformWhile {
+        emit(it)
+        it.loading
+    }

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtPairTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtPairTest.kt
@@ -1,7 +1,6 @@
 package com.revolut.flowdata.extensions
 
 import com.revolut.data.model.Data
-import com.revolut.flow_core.extensions.runFlowTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtTripleTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/CombineDataKtTripleTest.kt
@@ -1,7 +1,6 @@
 package com.revolut.flowdata.extensions
 
 import com.revolut.data.model.Data
-import com.revolut.flow_core.extensions.runFlowTest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/ExtractContentKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/ExtractContentKtTest.kt
@@ -60,57 +60,6 @@ class ExtractContentKtTest {
 
     //endregion
 
-    //region filterWhileLoading
-
-    @Test
-    fun `Loading items are skipped`() = runTest {
-        flowOf(
-            Data("A", null, loading = true),
-            Data("B", null, loading = false)
-        ).filterWhileLoading().extractContent().test {
-            assertEquals("B", expectMostRecentItem())
-        }
-    }
-
-    @Test
-    fun `Loading items with errors are skipped`() = runTest {
-        val error = IllegalStateException()
-
-        flowOf(
-            Data("A", error, loading = true),
-            Data("B", null, loading = false)
-        ).filterWhileLoading().extractContent().test {
-            assertEquals("B", expectMostRecentItem())
-        }
-    }
-
-    @Test
-    fun `Error after loading`() = runTest {
-        val error = IllegalStateException()
-
-        flowOf(
-            Data("A", null, loading = true),
-            Data("A", error, loading = false)
-        ).filterWhileLoading().extractContent().test {
-            assertEquals(error, awaitError())
-        }
-    }
-
-
-    @Test
-    fun `Error without content is extracted and terminates the stream`() = runTest {
-        val error = IllegalStateException()
-
-        flowOf(
-            Data("A", null, loading = true),
-            Data(null, error, loading = false)
-        ).filterWhileLoading().extractContent().test {
-            assertEquals(error, awaitError())
-        }
-    }
-
-    //endregion
-
     //region consumeErrors conditionally
 
     @Test

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlowTestKt.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/FlowTestKt.kt
@@ -1,4 +1,4 @@
-package com.revolut.flow_core.extensions
+package com.revolut.flowdata.extensions
 
 import app.cash.turbine.FlowTurbine
 import app.cash.turbine.test

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
@@ -1,0 +1,64 @@
+package com.revolut.flowdata.extensions
+
+import app.cash.turbine.test
+import com.revolut.data.model.Data
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class LoadingExtensionsKtTest {
+
+    //region filterWhileLoading
+
+    @Test
+    fun `Loading items are skipped`() = runTest {
+        flowOf(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false)
+        ).filterWhileLoading().extractContent().test {
+            Assertions.assertEquals("B", expectMostRecentItem())
+        }
+    }
+
+    @Test
+    fun `Loading items with errors are skipped`() = runTest {
+        val error = IllegalStateException()
+
+        flowOf(
+            Data("A", error, loading = true),
+            Data("B", null, loading = false)
+        ).filterWhileLoading().extractContent().test {
+            Assertions.assertEquals("B", expectMostRecentItem())
+        }
+    }
+
+    @Test
+    fun `Error after loading`() = runTest {
+        val error = IllegalStateException()
+
+        flowOf(
+            Data("A", null, loading = true),
+            Data("A", error, loading = false)
+        ).filterWhileLoading().extractContent().test {
+            Assertions.assertEquals(error, awaitError())
+        }
+    }
+
+
+    @Test
+    fun `Error without content is extracted and terminates the stream`() = runTest {
+        val error = IllegalStateException()
+
+        flowOf(
+            Data("A", null, loading = true),
+            Data(null, error, loading = false)
+        ).filterWhileLoading().extractContent().test {
+            Assertions.assertEquals(error, awaitError())
+        }
+    }
+
+    //endregion
+}

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
@@ -65,18 +65,79 @@ class LoadingExtensionsKtTest {
     //region takeUntilLoaded
 
     @Test
-    fun `Loaded item is returned and terminates the stream`() = runTest {
-        flowOf(
-            Data("A", null, loading = true),
-            Data("B", null, loading = false),
-            Data("C", null, loading = true),
-        ).takeUntilLoaded().test {
-            assertEquals(Data("A", null, loading = true), awaitItem())
-            assertEquals(Data("B", null, loading = false), awaitItem())
-            awaitComplete()
-            expectNoEvents()
+    fun `Loading item and loaded item are returned, and loaded item terminates the stream`() =
+        runTest {
+            flowOf(
+                Data("A", null, loading = true),
+                Data("B", null, loading = false),
+                Data("C", null, loading = true),
+            ).takeUntilLoaded().test {
+                assertEquals(Data("A", null, loading = true), awaitItem())
+                assertEquals(Data("B", null, loading = false), awaitItem())
+                awaitComplete()
+                expectNoEvents()
+            }
         }
-    }
+
+    @Test
+    fun `Loaded item, which is the first and the only item in the stream, is returned and terminates the stream`() =
+        runTest {
+            flowOf(
+                Data("A", null, loading = false),
+            ).takeUntilLoaded().test {
+                assertEquals(Data("A", null, loading = false), awaitItem())
+                awaitComplete()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `Loading item with error and loaded item are returned, and loaded item terminates the stream`() =
+        runTest {
+            val error = IllegalStateException()
+
+            flowOf(
+                Data("A", error, loading = true),
+                Data("B", null, loading = false),
+                Data("C", null, loading = true),
+            ).takeUntilLoaded().test {
+                assertEquals(Data("A", error, loading = true), awaitItem())
+                assertEquals(Data("B", null, loading = false), awaitItem())
+                awaitComplete()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `Loading item and loaded item with error are returned, and loaded item with error terminates the stream`() =
+        runTest {
+            val error = IllegalStateException()
+
+            flowOf(
+                Data("A", null, loading = true),
+                Data("B", error, loading = false),
+                Data("C", null, loading = true),
+            ).takeUntilLoaded().test {
+                assertEquals(Data("A", null, loading = true), awaitItem())
+                assertEquals(Data("B", error, loading = false), awaitItem())
+                awaitComplete()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `Loaded item with error, which is the first and the only item in the stream, is returned and terminates the stream`() =
+        runTest {
+            val error = IllegalStateException()
+
+            flowOf(
+                Data("A", error, loading = false),
+            ).takeUntilLoaded().test {
+                assertEquals(Data("A", error, loading = false), awaitItem())
+                awaitComplete()
+                expectNoEvents()
+            }
+        }
 
     //endregion
 }

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
@@ -3,6 +3,9 @@ package com.revolut.flowdata.extensions
 import app.cash.turbine.test
 import com.revolut.data.model.Data
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -57,6 +60,24 @@ class LoadingExtensionsKtTest {
             Data(null, error, loading = false)
         ).filterWhileLoading().extractContent().test {
             Assertions.assertEquals(error, awaitError())
+        }
+    }
+
+    //endregion
+
+    //region takeUntilLoaded
+
+    @Test
+    fun `Loaded item is returned and terminates the stream`() = runTest {
+        flowOf(
+            Data("A", null, loading = true),
+            Data("B", null, loading = false),
+            Data("C", null, loading = true),
+        ).takeUntilLoaded().test {
+            Assertions.assertEquals(Data("A", null, loading = true), awaitItem())
+            Assertions.assertEquals(Data("B", null, loading = false), awaitItem())
+            awaitComplete()
+            expectNoEvents()
         }
     }
 

--- a/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
+++ b/flow-extensions/src/test/kotlin/com/revolut/flowdata/extensions/LoadingExtensionsKtTest.kt
@@ -3,12 +3,9 @@ package com.revolut.flowdata.extensions
 import app.cash.turbine.test
 import com.revolut.data.model.Data
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
@@ -22,7 +19,7 @@ class LoadingExtensionsKtTest {
             Data("A", null, loading = true),
             Data("B", null, loading = false)
         ).filterWhileLoading().extractContent().test {
-            Assertions.assertEquals("B", expectMostRecentItem())
+            assertEquals("B", expectMostRecentItem())
         }
     }
 
@@ -34,7 +31,7 @@ class LoadingExtensionsKtTest {
             Data("A", error, loading = true),
             Data("B", null, loading = false)
         ).filterWhileLoading().extractContent().test {
-            Assertions.assertEquals("B", expectMostRecentItem())
+            assertEquals("B", expectMostRecentItem())
         }
     }
 
@@ -46,7 +43,7 @@ class LoadingExtensionsKtTest {
             Data("A", null, loading = true),
             Data("A", error, loading = false)
         ).filterWhileLoading().extractContent().test {
-            Assertions.assertEquals(error, awaitError())
+            assertEquals(error, awaitError())
         }
     }
 
@@ -59,7 +56,7 @@ class LoadingExtensionsKtTest {
             Data("A", null, loading = true),
             Data(null, error, loading = false)
         ).filterWhileLoading().extractContent().test {
-            Assertions.assertEquals(error, awaitError())
+            assertEquals(error, awaitError())
         }
     }
 
@@ -74,8 +71,8 @@ class LoadingExtensionsKtTest {
             Data("B", null, loading = false),
             Data("C", null, loading = true),
         ).takeUntilLoaded().test {
-            Assertions.assertEquals(Data("A", null, loading = true), awaitItem())
-            Assertions.assertEquals(Data("B", null, loading = false), awaitItem())
+            assertEquals(Data("A", null, loading = true), awaitItem())
+            assertEquals(Data("B", null, loading = false), awaitItem())
             awaitComplete()
             expectNoEvents()
         }


### PR DESCRIPTION
- Add `takeUntilLoaded` function for `Flow<Data<T>>`
- Extract tests for `filerWhileLoading` from `ExtractContentKtTest` to `LoadingExtensionsKtTest`
- Add test for `takeUntilLoaded`
- Fix package of `FlowTestKt`