### PR TITLE
add test 'attemptNoCacheOnlineRaceCondition' for subsequent fix

### DIFF
--- a/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
+++ b/dod/src/test/java/com/revolut/rxdata/dod/DodFunctionalTest.kt
@@ -2,6 +2,7 @@ package com.revolut.rxdata.dod
 
 import com.revolut.rxdata.core.extensions.takeUntilLoaded
 import io.reactivex.Single
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
@@ -44,6 +45,13 @@ class DodFunctionalTest {
 
     private val noCacheOfflineDod = DataObservableDelegate(
         fromNetwork = { Single.error(IllegalStateException("no network")) },
+        fromMemory = { null },
+        toMemory = toMemory,
+        fromStorage = { null },
+        toStorage = toStorage
+    )
+    private val noCacheOnlineDod = DataObservableDelegate<Unit, String>(
+        fromNetwork = { Single.fromCallable { "test" } },
         fromMemory = { null },
         toMemory = toMemory,
         fromStorage = { null },
@@ -131,7 +139,35 @@ class DodFunctionalTest {
         }
 
         val finishedWithLoadingTrueCount = isLastEmitLoadingMap.count { it.value }
-        assert( finishedWithLoadingTrueCount == 0) { "Finished with loading true count = $finishedWithLoadingTrueCount" }
+        assert(finishedWithLoadingTrueCount == 0) { "Finished with loading true count = $finishedWithLoadingTrueCount" }
+    }
+
+    @Disabled("waiting for fix")
+    @RepeatedTest(1000)
+    fun attemptNoCacheOnlineRaceCondition() {
+        val count = 3
+        val maxThreadDelay = 3
+        val maxDelay: Long = (count + 2).toLong() * maxThreadDelay + 30
+        val isLastEmitLoadingMap = ConcurrentHashMap<Int, Boolean>(count)
+
+        (1..count).map { num ->
+            val delay = Random.nextInt(0, maxThreadDelay).toLong()
+            sleep(delay)
+            Thread {
+                noCacheOnlineDod.observe(Unit, forceReload = true)
+                    .doOnNext {
+                        println("Stream $num: data emitted $it")
+                        isLastEmitLoadingMap[num] = it.loading
+                    }
+                    .test()
+                    .awaitTerminalEvent(maxDelay, MILLISECONDS)
+            }.apply { start() }
+        }.forEach {
+            it.join(maxDelay)
+        }
+
+        val finishedWithLoadingTrueCount = isLastEmitLoadingMap.count { it.value }
+        assert(finishedWithLoadingTrueCount == 0) { "Finished with loading true count = $finishedWithLoadingTrueCount" }
     }
 
 }


### PR DESCRIPTION
Currently this test is failing, but it is expected that there will be a fix soon, since issue is localised in logic of reusing `fromNetwork` observables.
