### PR TITLE
Reload from network when LazyReload was used before

### DIFF
--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -59,6 +59,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                 }
                 .doAfterSuccess { domain ->
                     failedNetworkRequests.remove(params)
+                    needToBeRefreshed.remove(params)
 
                     val data = Data(content = domain)
                     subject(params).onNext(data)
@@ -93,6 +94,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
      * even if forceReload == false and memory is not empty
      */
     private val failedNetworkRequests = ConcurrentHashMap<Params, Throwable>()
+    private val needToBeRefreshed = ConcurrentHashMap<Params, Boolean>()
 
     /**
      * Requests data from network and subscribes to updates
@@ -105,7 +107,10 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
             val memCache = fromMemory(params)
             val memoryIsEmpty = memCache == null
             val subject = subject(params)
-            val loading = loadingStrategy.refreshMemory || memoryIsEmpty || failedNetworkRequests.containsKey(params)
+            val loading = loadingStrategy.refreshMemory
+                    || memoryIsEmpty
+                    || failedNetworkRequests.containsKey(params)
+                    || (needToBeRefreshed[params] == true && loadingStrategy.refreshStorage)
 
             val observable: Observable<Data<Domain>> = if (memCache != null) {
                 concat(
@@ -124,6 +129,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                         val cachedObservable = if (needToFetchFromNetwork) {
                             just(cached)
                         } else {
+                            needToBeRefreshed[params] = true
                             just(cached.copy(loading = false))
                         }
                         concat(

--- a/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
+++ b/dod/src/main/java/com/revolut/rxdata/dod/DataObservableDelegate.kt
@@ -59,7 +59,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                 }
                 .doAfterSuccess { domain ->
                     failedNetworkRequests.remove(params)
-                    needToBeRefreshed.remove(params)
+                    memoryCacheIsFromStorage.remove(params)
 
                     val data = Data(content = domain)
                     subject(params).onNext(data)
@@ -94,7 +94,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
      * even if forceReload == false and memory is not empty
      */
     private val failedNetworkRequests = ConcurrentHashMap<Params, Throwable>()
-    private val needToBeRefreshed = ConcurrentHashMap<Params, Boolean>()
+    private val memoryCacheIsFromStorage = ConcurrentHashMap<Params, Boolean>()
 
     /**
      * Requests data from network and subscribes to updates
@@ -110,7 +110,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
             val loading = loadingStrategy.refreshMemory
                     || memoryIsEmpty
                     || failedNetworkRequests.containsKey(params)
-                    || (needToBeRefreshed[params] == true && loadingStrategy.refreshStorage)
+                    || (memoryCacheIsFromStorage[params] == true && loadingStrategy.refreshStorage)
 
             val observable: Observable<Data<Domain>> = if (memCache != null) {
                 concat(
@@ -129,7 +129,7 @@ class DataObservableDelegate<Params : Any, Domain : Any> constructor(
                         val cachedObservable = if (needToFetchFromNetwork) {
                             just(cached)
                         } else {
-                            needToBeRefreshed[params] = true
+                            memoryCacheIsFromStorage[params] = true
                             just(cached.copy(loading = false))
                         }
                         concat(


### PR DESCRIPTION
With the LoadingStrategy.LazyReload we can get permanent cache unintentionally. 
Case: 
call dod observe with the LoadingStrategy.LazyReload
and then call only dod observe with the LoadingStrategy.Auto
memory and storage cache will never be updated until the storage clean up